### PR TITLE
Add allowlist support for authorized employee IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # Verbiage-Trainer-V1
-Verbiage Trainer
+
+## Overview
+This Next.js project renders the Ramp Verbiage Trainer sign-in experience.
+
+## Configuring authorized users
+Set the `NEXT_PUBLIC_AUTHORIZED_USERS` environment variable to a comma-separated list of Ramp employee IDs that should have access to the trainer. For local development, create a `.env.local` file in the project root:
+
+```
+NEXT_PUBLIC_AUTHORIZED_USERS=1234,5678,9012
+```
+
+The UI will validate submitted employee IDs against this allowlist and display whether access is granted.
+
+## Development scripts
+- `npm run dev` – start the development server
+- `npm run build` – create a production build
+- `npm run start` – run the production build locally
+- `npm run lint` – lint the project

--- a/config/authorizedUsers.ts
+++ b/config/authorizedUsers.ts
@@ -1,0 +1,31 @@
+const normalizeList = (value: string | undefined): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+};
+
+/**
+ * Array of authorized Ramp employee IDs. Configure by setting the
+ * `NEXT_PUBLIC_AUTHORIZED_USERS` environment variable to a comma-separated list
+ * (e.g. "1234,5678,9012").
+ */
+export const AUTHORIZED_USERS = normalizeList(
+  process.env.NEXT_PUBLIC_AUTHORIZED_USERS,
+);
+
+export const hasAuthorizedUsersConfigured = AUTHORIZED_USERS.length > 0;
+
+export const isAuthorizedUser = (employeeId: string): boolean => {
+  const normalizedId = employeeId.trim();
+
+  if (normalizedId.length === 0) {
+    return false;
+  }
+
+  return AUTHORIZED_USERS.some((authorizedId) => authorizedId === normalizedId);
+};


### PR DESCRIPTION
## Summary
- add a configuration helper that parses the NEXT_PUBLIC_AUTHORIZED_USERS allowlist
- update the sign-in form to validate submitted employee IDs and surface feedback
- document how to configure authorized IDs through environment variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf4783976c832b814aa58f53e1aa5b